### PR TITLE
igraph/network app: code refactor; ui fixes

### DIFF
--- a/inst/www/d3-graph.js
+++ b/inst/www/d3-graph.js
@@ -1,0 +1,250 @@
+(function (window) {
+	'use strict';
+
+	var d3graph = { name: "graph with force layout based on d3.js" };
+
+	d3graph.generate = function(el, properties, nodes, edges, verticesAttributes, tooltipInfo) {
+		var markerSize = properties.markerSize || 3;
+		var currentTranslation = null;
+	  	var currentScale = null;
+	  	var zoom;
+
+		var force = d3.layout.force()
+			.nodes(nodes)
+			.links(edges)
+			.charge(properties.charge || 200)
+			.linkDistance(properties.linkDistance || 50)
+			.linkStrength(properties.linkStrength || 0.5)
+			.size([properties.width || 400 , properties.height || 400])
+			.start();
+
+		var svg = d3.select(el).select("svg");
+		svg.remove();
+	  
+		$(el).html("");
+	  
+		svg = d3.select(el).append("svg");
+
+		/**
+		Add svg properties to become responsive (adjusting width and height)
+		*/
+		svg.attr("id", "graph")
+			.attr("pointer-events", "all")
+			.attr("width", properties.width)
+			.attr("height", properties.height)
+			.attr("viewBox", "0, 0, " + properties.width + ", " + properties.height)
+			.attr("preserveAspectRatio", "xMidYMid meet");
+
+		var background = svg.append('svg:g');
+
+		background.append('svg:rect')
+			.attr('width', properties.width)
+			.attr('height', properties.height)
+			.attr('fill', 'white');
+
+		var graph = $("#graph");
+		var aspect = graph.width() / graph.height();
+		var container = graph.parent();
+
+		$(window).on("resize", function() {
+			var targetWidth = container.width();
+			graph.attr("width", targetWidth);
+			graph.attr("height", Math.round(targetWidth / aspect));
+		}).trigger("resize");
+
+		  /**
+			Zooming the graph
+		  */
+	  	function zoomGraph() {
+			if (currentTranslation !== null && currentScale !== null) {
+			  	zoom.translate(currentTranslation);
+			  	zoom.scale(currentScale);
+			  	currentTranslation = null;
+			  	currentScale = null;
+			}
+			background.attr('transform', 'translate(' + d3.event.translate + ')' +
+					' scale(' + d3.event.scale + ')');
+	  	}
+
+
+	  	$("#zoomButton").unbind('click').bind('click',function() {
+			if ($(this).hasClass('active')) {
+				$(this).removeClass('active');
+				if (currentTranslation === null) 
+					currentTranslation = zoom.translate();
+				if (currentScale === null) 
+					currentScale = zoom.scale();
+				background.call(zoom.on('zoom', null));
+				g.call(force.drag);
+			}
+			else {
+			  	$(this).addClass('active');
+			  	background.call(zoom = d3.behavior.zoom().on('zoom', zoomGraph));
+			  	g.on('mousedown.drag', null);
+			}
+	  	});
+
+	  	svg.append("svg:defs").selectAll("marker")
+			.data(["end"])      
+	  	.enter().append("svg:marker")    // This section adds in the arrows
+			.attr("id", String)
+			.attr("viewBox", "0 -5 10 10")
+			.attr("refX", function(d) { return 3*markerSize; })
+			.attr("markerWidth", markerSize)
+			.attr("markerHeight", markerSize)
+			.attr("orient", "auto")
+			.style("fill", "#6E6E6E")
+	  	.append("svg:path")
+			.attr("d", "M0,-5L10,0L0,5");
+
+	  
+	  	// add the links and the arrows
+	  	var path = background.selectAll("path")
+			.data(edges)
+		.enter().append("svg:path")
+			.attr("class", "link")
+			.style("stroke", "#6E6E6E")
+			.style("stroke-opacity", function(d) { return strokeOpacity(d, properties); })
+			.style("stroke-width", function(d) { return strokeWidth(d, properties); })
+			.attr("marker-end", "url(#end)");
+
+	  if (properties.directed)
+			svg.selectAll("path").attr("marker-end", "url(#end)");
+	  
+	  /** 
+	  Adding vertices on the graph
+	  g - vertex contsiting of:
+		|____circle
+		|____label (showing on mouseover)
+	  */
+	  var vertexes = background.selectAll("g")
+		  .data(nodes);
+
+	  var g = vertexes.enter()
+		  .append("g")
+		  .attr("class", "graph-node")
+		  .call(force.drag);
+
+	  var circle = g.append("circle")
+		  .attr("class", "circle")
+		  .attr("r", function(d) { return circleRadius(d, properties); })
+		  .attr("fill", function(d) {
+			return d.color;
+		  })
+		  .style("stroke", "#fff")
+		  .style("stroke-width", "1px");
+
+	  /**
+	  Creating tooltip
+	  */
+		$('circle').tipsy({ 
+			gravity: 'w', 
+			html: true, 
+			title: function() {
+				var d = this.__data__;
+				return formatTooltip(d, verticesAttributes, properties, tooltipInfo);
+			}
+		});
+
+		var radiusArray = [];
+		d3.selectAll("circle").each( function(d, i){
+		  radiusArray[this.__data__.index] = d3.select(this).attr("r");
+		});
+
+		force.on("tick", function() {
+			path
+				.attr("d", function(d) { return getPathTick(d, radiusArray); });
+			circle
+				.attr("transform", getCircleTransformTick);        
+		});
+
+	};
+
+	if (typeof define === 'function' && define.amd) {
+		define("d3graph", ["d3"], d3graph);
+	} else if ('undefined' !== typeof exports && 'undefined' !== typeof module) {
+		module.exports = d3graph;
+	} else {
+		window.d3graph = d3graph;
+	}
+})(window);
+
+function circleRadius(d, properties) {
+	var countedRadius = properties.vertexSizeMax*(d.property/properties.maxVertexProperty);
+	return (d.property && properties.maxVertexProperty) ? 
+		Math.max(properties.vertexSizeMin, countedRadius) : properties.vertexSizeMin;
+}
+
+function strokeWidth(d, properties) {
+	return (d.property) ? Math.max(3,10*(d.property/properties.maxEdgeProperty)) : 3;
+}
+
+function strokeOpacity(d, properties) {
+	return (d.property) ? Math.max(0.3,(d.property/properties.maxEdgeProperty)) : 0.5;
+}
+
+function getCircleTransformTick(d) {
+	return "translate(" + d.x + "," + d.y + ")";
+}
+
+function getPathTick(d, radiusArray) {
+	var r = radiusArray[d.target.index];
+	var dr = 0;
+	var temp  = Math.sqrt(r * r * (d.source.y - d.target.y) * (d.source.y - d.target.y) / 
+		((d.source.x - d.target.x)*(d.source.x - d.target.x) + (d.source.y - d.target.y)*(d.source.y - d.target.y)));
+
+	var yr, xr;
+	if (d.source.y < d.target.y) {
+		yr = d.target.y - temp;
+		xr = d.target.x - temp*(d.source.x - d.target.x)/(d.source.y - d.target.y);
+	}
+	else {
+		yr = d.target.y + temp;
+		xr = d.target.x + temp*(d.source.x - d.target.x)/(d.source.y - d.target.y);
+	}
+						
+	return "M" + 
+		d.source.x + "," + 
+		d.source.y + "A" + 
+		dr + "," + dr + " 0 0,1 " + 
+		xr + "," + 
+		yr;
+}
+
+function formatTooltip(d, verticesAttributes, properties, tooltipInfo) {
+	var tooltipText = '';
+				
+	if (properties.vertexColor !== 'None' && properties.vertexColor !== null)
+		tooltipText += formatColorInfo(d, verticesAttributes, properties);
+
+	if (tooltipInfo !== null)
+		tooltipText += formatTooltipTable(d, tooltipInfo, verticesAttributes);	
+
+	return '<span class="tipsy-title">' + d.name + '</span><br/>' + "\n" + tooltipText;
+}
+
+function formatColorInfo(d, verticesAttributes, properties) {
+	var colorLegend = (verticesAttributes[properties.vertexColor][d.index] !== null) ? 
+						verticesAttributes[properties.vertexColor][d.index] : 'NA';
+	var tooltipText = '<span style="text-align: left; font-size: 5em; color: ' + d.color;
+	tooltipText += '">' + '&#9679' + '</span><p><b>' + colorLegend + '</b></p>';
+	return tooltipText;
+}
+
+function formatTooltipTable(d, data, verticesAttributes) {
+	var tooltipText = '<table>';
+
+	for (i = 0; i < data.length; i++)
+	{
+		tooltipText += '<tr><td style="text-align: left">';
+		tooltipText += data[i].toUpperCase() + '</td><td style="text-align: right">';
+		tooltipText += formatAttribute(verticesAttributes[data[i]][d.index]);
+		tooltipText += '</td></tr>';
+	}
+	tooltipText += '</table>';
+	return tooltipText;
+}
+
+function formatAttribute(value) {
+	return isNaN(value) ? value : Number(value).toFixed(2);
+}

--- a/inst/www/igraph-graph.js
+++ b/inst/www/igraph-graph.js
@@ -2,298 +2,118 @@
 var networkOutputBinding = new Shiny.OutputBinding();
   $.extend(networkOutputBinding, {
 
-    find: function(scope) {
-      return $(scope).find('.shiny-network-output');
-    },
-    
-    renderValue: function(el, data) {
-      
-      /**
-      Used variables 
-      */
-      var width = 7/12* $(window).width();
-      var height = 0.75 * $(window).height();
-      var maxVertexProperty = 0.0;
-      var maxEdgeProperty = 0.0;
-      var nodes = new Array();
-      var edges = data.links;
-      var vertices = data.vertices;
-      var d3properties = data.d3;
-      var tooltipInfo = data.tooltipInfo;
-      var verticesAttributes = data.verticesAttributes;
-      var vertexRadius = data.vertexRadius;
-      var vertexColor = data.vertexColor;
-      var graphType = data.graphType;
-      var color = d3properties[0].color;
-      var minColor = 'lightyellow';
-      var colorScalePicker = d3.scale.category10().domain(d3.range(0,10));
-      var scale = d3.scale.linear().range([colorScalePicker(color), minColor]);
+	find: function(scope) {
+	  return $(scope).find('.shiny-network-output');
+	},
+	
+	renderValue: function(el, data) {
+		var properties = getProperties(data);
+		var projectionColors = getProjectionColors(data.vertices, data.verticesAttributes, properties);
+	  	var nodes = getNodes(data.vertices, data.verticesAttributes, properties, projectionColors);
+	  	var edges = data.links;
+	  	properties.maxVertexProperty = maxVertexProperty(nodes) || 0;
+	  	properties.maxEdgeProperty = maxEdgeProperty(edges) || 0;
 
-      var zoomButtonHtml = '<button type="button" class="btn btn-default btn-lg" id="zoomButton">Zooming</button>'
-      $("#player").html(zoomButtonHtml);
-      $("#logo").removeAttr("style");
-      
-      var stringsForColoring = [];
-      var projectionColors = {};
+	  
+	  var vertices = data.vertices;
+	  var tooltipInfo = data.tooltipInfo;
+	  var verticesAttributes = data.verticesAttributes;
 
-      for (var i = 0; i < vertices.length; i++)
-      {
-        value = (vertexColor != 'None' && vertexColor != null) ? verticesAttributes[vertexColor][i] : 'NA';
-        stringsForColoring.push(value)
-      }
+	  
 
-      // leave only unique elements
-      stringsForColoring = stringsForColoring.filter(function(elem, pos, self) {
-          return self.indexOf(elem) == pos;
-      })
-      for (var stringId in stringsForColoring)
-      {
-        if (!projectionColors[stringsForColoring[stringId]])
-          projectionColors[stringsForColoring[stringId]] = scale(stringId/stringsForColoring.length);
-      }
-      for (var i = 0; i < vertices.length; i++)
-      {
-        value = (vertexColor != 'None' && vertexColor != null) ? verticesAttributes[vertexColor][i] : 'NA';
-        property = (vertexRadius != 'None' && vertexRadius != null) ? verticesAttributes[vertexRadius][i] : null;
-        nodes.push({"name": vertices[i], "property" : property, "color" : projectionColors[value]});
-      }
+	  //var zoomButtonHtml = '<button type="button" class="btn btn-default btn-lg" id="zoomButton">Zooming</button>'
+	  //$("#player").html(zoomButtonHtml);
+	  //$("#logo").removeAttr("style");
 
-      /**
-      Maximum and minimum vertices values - for normalization
-      */
-      maxVertexProperty = nodes.reduce(function(acc, vertex) { 
-        if (Number(vertex.property) > acc) 
-          return Number(vertex.property); 
-        else return acc}, 0);
-
-      maxEdgeProperty = edges.reduce(function(acc, edge) { 
-        if (Number(edge.property) > acc) 
-          return Number(edge.property); 
-        else return acc;  }, 0)
-
-      /**
-      Creating d3 graph
-      */
-      var force = d3.layout.force()
-        .nodes(nodes)
-        .links(edges)
-        .charge(d3properties[0].charge)
-        .linkDistance(d3properties[0].linkDistance)
-        .linkStrength(d3properties[0].linkStrength)
-        .size([width, height])
-        .start();
-      
-
-
-      //remove the old graph
-      var svg = d3.select(el).select("svg");
-      svg.remove();
-      
-      $(el).html("");
-      
-      //append a new one
-      svg = d3.select(el).append("svg");
-
-      /**
-      Add svg properties to become responsive (adjusting width and height)
-      */
-      svg.attr("id", "graph")
-        .attr("pointer-events", "all")
-        .attr("width", width)
-        .attr("height", height)
-        .attr("viewBox", "0, 0, " + width + ", " + height)
-        .attr("preserveAspectRatio", "xMidYMid meet");
-
-      var background = svg.append('svg:g');
-
-      background.append('svg:rect')
-        .attr('width', width)
-        .attr('height', height)
-        .attr('fill', 'white');
-
-      var graph = $("#graph"),
-          aspect = graph.width() / graph.height(),
-          container = graph.parent();
-
-      $(window).on("resize", function() {
-          var targetWidth = container.width();
-          graph.attr("width", targetWidth);
-          graph.attr("height", Math.round(targetWidth / aspect));
-      }).trigger("resize");
-
-      /**
-        Zooming the graph
-      */
-      function zoomGraph() {
-        if (currentTranslation != null && currentScale != null)
-        {
-          zoom.translate(currentTranslation);
-          zoom.scale(currentScale)
-          currentTranslation = null;
-          currentScale = null;
-        }
-        background.attr("transform", "translate(" +  zoom.translate() + ")scale(" + zoom.scale() + ")");
-      }
-
-      var currentTranslation = null;
-      var currentScale = null;
-      $("#zoomButton").click(function(){
-        if ($(this).hasClass('active'))
-        {
-          $(this).removeClass('active');
-          if (currentTranslation == null) currentTranslation = zoom.translate();
-          if (currentScale == null) currentScale = zoom.scale();
-          background.call(zoom = d3.behavior.zoom().on("zoom", null));
-          g.call(force.drag);
-        }
-        else
-        {
-          $(this).addClass('active');
-          background.call(zoom = d3.behavior.zoom().on("zoom", zoomGraph));
-          g.on('mousedown.drag', null);
-        }
-      })
-
-      var markerSize = 3;
-
-      svg.append("svg:defs").selectAll("marker")
-        .data(["end"])      // Different link/path types can be defined here
-      .enter().append("svg:marker")    // This section adds in the arrows
-        .attr("id", String)
-        .attr("viewBox", "0 -5 10 10")
-        .attr("refX", function(d) { return 3*markerSize; })
-        .attr("markerWidth", markerSize)
-        .attr("markerHeight", markerSize)
-        .attr("orient", "auto")
-        .style("fill", "#6E6E6E")
-      .append("svg:path")
-        .attr("d", "M0,-5L10,0L0,5");
-
-      
-      // add the links and the arrows
-      var path = background.selectAll("path")
-          .data(edges)
-        .enter().append("svg:path")
-          .attr("class", "link")
-          .style("stroke", "#6E6E6E")
-          .style("stroke-opacity", function(d) { return (d.property) ? Math.max(0.3,(d.property/maxEdgeProperty)) : 0.5; })
-          .style("stroke-width", function(d) { return (d.property) ? Math.max(3,10*(d.property/maxEdgeProperty)) : 3; })
-          .attr("marker-end", "url(#end)");
-
-      if (d3properties[0].directed)
-      {
-        svg.selectAll("path").attr("marker-end", "url(#end)")
-      }
-      
-      /** 
-      Adding vertices on the graph
-      g - vertex contsiting of:
-        |____circle
-        |____label (showing on mouseover)
-      */
-      var vertexes = background.selectAll("g")
-          .data(nodes);
-
-      var g = vertexes.enter()
-          .append("g")
-          .attr("class", "graph-node")
-          .call(force.drag);
-
-      var circle = g.append("circle")
-          .attr("class", "circle")
-          .attr("r", function(d) { return (d.property && maxVertexProperty) ? 
-            Math.max(d3properties[0].vertexSizeMin, d3properties[0].vertexSizeMax*(d.property/maxVertexProperty)) : d3properties[0].vertexSizeMin; } )
-          .attr("fill", function(d) {
-            return d.color;
-          })
-          .style("stroke", "#fff")
-          .style("stroke-width", "1px");
-
-      /**
-      Creating tooltip
-      */
-      $('circle').tipsy({ 
-        gravity: 'w', 
-        html: true, 
-        title: function() {
-        var d = this.__data__;
-            var properties = '';
-            
-            if (vertexColor != 'None' && vertexColor != null)
-            {
-              colorLegend = (verticesAttributes[vertexColor][d.index] != null) ? verticesAttributes[vertexColor][d.index] : 'NA';
-              properties += '<span style="text-align: left; font-size: 5em; color: ' + d.color + '">' + '&#9679' + '</span><p><b>' + colorLegend + '</b></p>';
-            }             
-
-            if (tooltipInfo != null)
-            {
-              properties += '<table>';
-
-              for (i = 0; i < tooltipInfo.length; i++)
-              {
-                properties += '<tr><td style="text-align: left">' + tooltipInfo[i].toUpperCase() + '</td><td style="text-align: right">' + verticesAttributes[tooltipInfo[i]][d.index] + '</td></tr>';
-              }
-              properties += '</table>';
-            }
-            
-            return '<span class="tipsy-title">' + d.name + '</span><br/>' + "\n" + properties;
-        }
-      });
-
-      var radiusArray = new Array();
-      d3.selectAll("circle").each( function(d, i){
-                      radiusArray[this.__data__.index] = d3.select(this).attr("r");
-                    });
-
-      force.on("tick", function() {
-        path.attr("d", function(d) {
-                    var r = radiusArray[d.target.index];
-                    var dr = 0;
-                    var temp  = Math.sqrt(r * r * (d.source.y - d.target.y) * (d.source.y - d.target.y) / 
-                        ((d.source.x - d.target.x)*(d.source.x - d.target.x) + (d.source.y - d.target.y)*(d.source.y - d.target.y)));
-
-                    var yr, xr;
-                    if (d.source.y < d.target.y) 
-                      {
-                        yr = d.target.y - temp;
-                        xr = d.target.x - temp*(d.source.x - d.target.x)/(d.source.y - d.target.y);
-                      }
-                      else
-                      {
-                        yr = d.target.y + temp;
-                        xr = d.target.x + temp*(d.source.x - d.target.x)/(d.source.y - d.target.y);
-                      }
-                    
-                return "M" + 
-                    d.source.x + "," + 
-                    d.source.y + "A" + 
-                    dr + "," + dr + " 0 0,1 " + 
-                    xr + "," + 
-                    yr;
-            });
-
-        circle
-          .attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });        
-      });
-    
-      /**
-      Interval for indicating whether shiny is busy
-      Shows loading image when R is doing stuff
-      */
-      setInterval(function(){
-        if ($('html').attr('class')=='shiny-busy') {
-          setTimeout(function() {
-            if ($('html').attr('class')=='shiny-busy') {
-              $('div.busy').show()
-            }
-          }, 1000)
-        } else {
-          $('div.busy').hide()
-        }
-      }, 100)
-
-    }
+	  d3graph.generate(el, properties, nodes, edges, verticesAttributes, tooltipInfo);
+	  
+	}
 
   });
 
-  Shiny.outputBindings.register(networkOutputBinding, 'pawluczuk.networkbinding');
+/**
+  Interval for indicating whether shiny is busy
+  Shows loading image when R is doing stuff
+  */
+setInterval(function(){
+	if ($('html').attr('class')=='shiny-busy') {
+		setTimeout(function() {
+			if ($('html').attr('class')=='shiny-busy') 
+				$('div.busy').show();	
+	  	}, 1000);
+	} 
+	else 
+		$('div.busy').hide();
+}, 100);
+
+function maxVertexProperty(data) {
+	return data.reduce(function(acc, vertex) { 
+		if (Number(vertex.property) > acc) 
+		  return Number(vertex.property); 
+		else return acc}, 0);
+}
+
+function maxEdgeProperty(data) {
+	return data.reduce(function(acc, edge) { 
+		if (Number(edge.property) > acc) 
+		  return Number(edge.property); 
+		else return acc;  }, 0)
+}
+
+function getProperties(data) {
+	var properties = data.d3 || {};
+	properties.vertexRadius = data.vertexRadius;
+	properties.vertexColor 	= data.vertexColor;
+	properties.graphType 	= data.graphType;
+	properties.width 		= 7/12* $(window).width();
+	properties.height 		= 0.75 * $(window).height();
+	properties.markerSize	= 3;
+	return properties;
+}
+
+function getProjectionColors(vertices, verticesAttributes, properties) {
+	var minColor = 'lightyellow';
+	var colorScalePicker = d3.scale.category10().domain(d3.range(0,10));
+	var scale = d3.scale.linear().range([colorScalePicker(properties.color), minColor]);
+	var stringsForColoring = getUniqueVertciesValue(vertices, verticesAttributes, properties);
+	var projectionColors = {};
+
+  	for (var stringId in stringsForColoring) {
+  		if (!projectionColors[stringsForColoring[stringId]])
+	  		projectionColors[stringsForColoring[stringId]] = scale(stringId/stringsForColoring.length);
+  	}
+
+  	return projectionColors;
+}
+
+function getUniqueVertciesValue(data, dataAttr, properties) {
+	var stringsForColoring = [];
+
+	for (var i = 0; i < data.length; i++){
+		value = (properties.vertexColor !== 'None' && properties.vertexColor !== null) ? 
+				dataAttr[properties.vertexColor][i] : 'NA';
+		stringsForColoring.push(value);
+	}
+
+  	// leave only unique elements
+  	stringsForColoring = stringsForColoring.filter(function(elem, pos, self) {
+	  	return self.indexOf(elem) == pos;
+  	});
+
+  	return stringsForColoring;
+}
+
+function getNodes(vertices, verticesAttributes, properties, projectionColors) {
+	if (!vertices || !verticesAttributes)
+		return [];
+	var nodes = [];
+	for (var i = 0; i < vertices.length; i++) {
+		value = (properties.vertexColor !== 'None' && properties.vertexColor !== null) ? 
+				verticesAttributes[properties.vertexColor][i] : 'NA';
+		property = (properties.vertexRadius !== 'None' && properties.vertexRadius !== null) ? 
+				verticesAttributes[properties.vertexRadius][i] : null;
+		nodes.push({"name": vertices[i], "property" : property, "color" : projectionColors[value]});
+	}
+	return nodes;
+}
+Shiny.outputBindings.register(networkOutputBinding, 'pawluczuk.networkbinding');

--- a/inst/www/tipsy.css
+++ b/inst/www/tipsy.css
@@ -14,6 +14,12 @@ div.busy {
   border-radius: 5px;
 }
 
+#logo > img {
+  width: 100px;
+  height: auto;
+}
+
+
 .tipsy-title {font-weight:bold; font-size: 1.2em;}
 .tipsy { font-size: 0.8em; position: absolute; padding: 5px; z-index: 100000; }
   .tipsy-inner { background-color: #fff; color: #6E6E6E; padding: 5px 8px 4px 8px; text-align: center; -webkit-box-shadow: 4px 4px 10px 0px rgba(50, 50, 50, 0.75);


### PR DESCRIPTION
Shiny app for igraph/network graphs has refactored js code (split js file into two files: one responsible for shiny binding and data preparation, second for d3.js visualization), UI has been changed: fixed ICM logo, properties split into 3 tabs (d3 properties/R properties/info)