### PR TITLE
Tooltip fixes

### DIFF
--- a/inst/www/d3-graph.js
+++ b/inst/www/d3-graph.js
@@ -1,21 +1,35 @@
 (function (window) {
 	'use strict';
 
-	var d3graph = { name: "graph with force layout based on d3.js" };
+	var d3graph = { 
+		name: "graph with force layout based on d3.js",
+		defaults = {
+			charge: 200,
+			linkDistance: 50,
+			linkStrength: 0.5,
+			width: 400,
+			height: 400,
+			markerSize: 3
+		}
+	};
 
 	d3graph.generate = function(el, properties, nodes, edges, verticesAttributes, tooltipInfo) {
-		var markerSize = properties.markerSize || 3;
+		properties = {
+			...this.defaults,
+			...properties
+		};
+		var markerSize = properties.markerSize;
 		var currentTranslation = null;
-	  	var currentScale = null;
-	  	var zoom;
+	  var currentScale = null;
+	  var zoom;
 
 		var force = d3.layout.force()
 			.nodes(nodes)
 			.links(edges)
-			.charge(properties.charge || 200)
-			.linkDistance(properties.linkDistance || 50)
-			.linkStrength(properties.linkStrength || 0.5)
-			.size([properties.width || 400 , properties.height || 400])
+			.charge(properties.charge)
+			.linkDistance(properties.linkDistance)
+			.linkStrength(properties.linkStrength)
+			.size([properties.width, properties.height])
 			.start();
 
 		var svg = d3.select(el).select("svg");
@@ -24,22 +38,22 @@
 		$(el).html("");
 	  
 		svg = d3.select(el).append("svg");
-
+		
 		/**
 		Add svg properties to become responsive (adjusting width and height)
 		*/
 		svg.attr("id", "graph")
 			.attr("pointer-events", "all")
-			.attr("width", properties.width || 400)
-			.attr("height", properties.height || 400)
-			.attr("viewBox", "0, 0, " + properties.width || 400 + ", " + properties.height || 400)
+			.attr("width", properties.width)
+			.attr("height", properties.height)
+			.attr("viewBox", "0, 0, " + properties.width + ", " + properties.height)
 			.attr("preserveAspectRatio", "xMidYMid meet");
 
 		var background = svg.append('svg:g');
 
 		background.append('svg:rect')
-			.attr('width', properties.width || 400)
-			.attr('height', properties.height || 400)
+			.attr('width', properties.width)
+			.attr('height', properties.height)
 			.attr('fill', 'white');
 
 		var graph = $("#graph");

--- a/inst/www/d3-graph.js
+++ b/inst/www/d3-graph.js
@@ -3,14 +3,15 @@
 
 	var d3graph = { 
 		name: "graph with force layout based on d3.js",
-		defaults = {
-			charge: 200,
-			linkDistance: 50,
-			linkStrength: 0.5,
-			width: 400,
-			height: 400,
-			markerSize: 3
-		}
+	};
+
+	d3graph.defaults = {
+		charge: 200,
+		linkDistance: 50,
+		linkStrength: 0.5,
+		width: 400,
+		height: 400,
+		markerSize: 3
 	};
 
 	d3graph.generate = function(el, properties, nodes, edges, verticesAttributes, tooltipInfo) {

--- a/inst/www/jquery.tipsy.js
+++ b/inst/www/jquery.tipsy.js
@@ -103,12 +103,12 @@
         },
         
         fixTitle: function() {
-            var $e = this.$element;
-            
+            var $e = $(this.$element);
             if ($e.attr('title') || typeof($e.attr('original-title')) != 'string') {
                 $e.attr('original-title', $e.attr('title') || '').removeAttr('title');
             }
-            if (typeof $e.context.nearestViewportElement == 'object'){                                                        
+
+            if (typeof $e[0].nearestViewportElement == 'object'){                                                        
                 if ($e.children('title').length){
                     $e.append('<original-title>' + ($e.children('title').text() || '') + '</original-title>')
                         .children('title').remove();


### PR DESCRIPTION
Fixes tooltip issues that were caused by two elements:
* invalid evaluation of viewBox dimensions for svg graph
* invalid (possibly deprecated) use of `.context` property

Tested with all types of supported networks:

`network`:
<img width="1280" alt="Screenshot 2020-03-28 at 22 19 37" src="https://user-images.githubusercontent.com/5955398/77835296-40ac4280-7143-11ea-9e8e-ee9a6e163348.png">

`networkDynamic`:
<img width="1280" alt="Screenshot 2020-03-28 at 22 22 40" src="https://user-images.githubusercontent.com/5955398/77835298-42760600-7143-11ea-9c33-fc54d33e2698.png">

`igraph`:
<img width="1280" alt="Screenshot 2020-03-28 at 22 18 00" src="https://user-images.githubusercontent.com/5955398/77835294-3d18bb80-7143-11ea-9c3d-cfa1d92e157c.png">
